### PR TITLE
URLSession: Cancel underlying data task when parent task is cancelled

### DIFF
--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -23,17 +23,27 @@ public extension URLSession {
     ///   as well as a `URLResponse` representing the server's response.
     /// - throws: Any error encountered while performing the data task.
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = self.dataTask(with: request) { data, response, error in
-                guard let data = data, let response = response else {
-                    let error = error ?? URLError(.badServerResponse)
-                    return continuation.resume(throwing: error)
+        var dataTask: URLSessionDataTask?
+        let onCancel = { dataTask?.cancel() }
+
+        return try await withTaskCancellationHandler(
+            handler: {
+                onCancel()
+            },
+            operation: {
+                try await withCheckedThrowingContinuation { continuation in
+                    dataTask = self.dataTask(with: request) { data, response, error in
+                        guard let data = data, let response = response else {
+                            let error = error ?? URLError(.badServerResponse)
+                            return continuation.resume(throwing: error)
+                        }
+
+                        continuation.resume(returning: (data, response))
+                    }
+
+                    dataTask?.resume()
                 }
-
-                continuation.resume(returning: (data, response))
             }
-
-            task.resume()
-        }
+        )
     }
 }

--- a/Tests/URLSessionTests.swift
+++ b/Tests/URLSessionTests.swift
@@ -64,6 +64,21 @@ final class URLSessionTests: XCTestCase {
             verifyThatError(error, containsURL: invalidURL)
         }
     }
+
+    func testCancellingParentTaskCancelsDataTask() async throws {
+        let task = Task { try await session.data(from: fileURL) }
+        Task { task.cancel() }
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected error to be thrown")
+        } catch let error as URLError {
+            verifyThatError(error, containsURL: fileURL)
+            XCTAssertEqual(error.code, .cancelled)
+        } catch {
+            XCTFail("Invalid error thrown: \(error)")
+        }
+    }
 }
 
 private extension URLSessionTests {


### PR DESCRIPTION
Use the `withTaskCancellationHandler` function to get access to a cancellation handler, within which we can then cancel the underlying `URLSessionDataTask` that's used to perform the actual network call.