### PR TITLE
Fix an issue leading to non-cancelled action

### DIFF
--- a/Sources/View+Async.swift
+++ b/Sources/View+Async.swift
@@ -18,9 +18,18 @@ public extension View {
         priority: TaskPriority = .userInitiated,
         _ action: @escaping () async -> Void
     ) -> some View {
-        var task: Task<Void, Never>?
+        modifier(AsyncTaskModifier(priority: priority, action: action))
+    }
+}
 
-        return onAppear {
+private struct AsyncTaskModifier: ViewModifier {
+    
+    @State private var task: Task<Void, Never>?
+    let priority: TaskPriority
+    let action: () async -> Void
+
+    func body(content: Content) -> some View {
+        content.onAppear {
             task = Task(priority: priority) {
                 await action()
             }


### PR DESCRIPTION
When `onDisappear` is called, it might try to cancel a non-existing task when the view body has been re-evaluated between `onAppear` and `onDisappear`. Storing the task in a `@State` fixes this issue.

As showcased in the following video, this fix should now behave like the iOS 15+ `task { ... }` modifier.

[![Screen Shot 2021-12-20 at 16 35 50](https://user-images.githubusercontent.com/63070/146793228-77ea6beb-8e1f-478d-b1ef-53cbfcd96780.jpg)](https://share.getcloudapp.com/2Nuv1xKY)

