### PR TITLE
Make SwiftUI task modifier cancel the correct task after updates

### DIFF
--- a/Sources/View+Async.swift
+++ b/Sources/View+Async.swift
@@ -18,16 +18,29 @@ public extension View {
         priority: TaskPriority = .userInitiated,
         _ action: @escaping () async -> Void
     ) -> some View {
-        var task: Task<Void, Never>?
+        modifier(TaskModifier(
+            priority: priority,
+            action: action
+        ))
+    }
+}
 
-        return onAppear {
-            task = Task(priority: priority) {
-                await action()
+private struct TaskModifier: ViewModifier {
+    var priority: TaskPriority
+    var action: () async -> Void
+
+    @State private var task: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                task = Task(priority: priority) {
+                    await action()
+                }
             }
-        }
-        .onDisappear {
-            task?.cancel()
-            task = nil
-        }
+            .onDisappear {
+                task?.cancel()
+                task = nil
+            }
     }
 }

--- a/Tests/ViewTests.swift
+++ b/Tests/ViewTests.swift
@@ -39,7 +39,14 @@ final class ViewTests: XCTestCase {
     func testTaskIsCancelledWhenViewDisappears() {
         class Coordinator: ObservableObject {
             @Published private(set) var showTaskView = true
+            @Published private(set) var taskViewDidUpdate = false
             @Published var taskError: Error?
+
+            func updateTaskViewAfterDelay() {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    self.taskViewDidUpdate = true
+                }
+            }
 
             func hideTaskViewAfterDelay() {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -53,7 +60,7 @@ final class ViewTests: XCTestCase {
 
             var body: some View {
                 if coordinator.showTaskView {
-                    Color.clear
+                    Text(coordinator.taskViewDidUpdate ? "Updated" : "Not updated")
                         .task {
                             do {
                                 // Make the task wait for 10 seconds, which will
@@ -65,6 +72,7 @@ final class ViewTests: XCTestCase {
                             }
                         }
                         .onAppear {
+                            coordinator.updateTaskViewAfterDelay()
                             coordinator.hideTaskViewAfterDelay()
                         }
                 }


### PR DESCRIPTION
Turn the task generated by the SwiftUI `task` modifier into a `State` property, so that it's retained across view updates, and so that the correct task is cancelled if the view disappears before the task has been completed.