### PR TITLE
Add support for macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 
 let package = Package(
     name: "AsyncCompatibilityKit",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
         .library(
             name: "AsyncCompatibilityKit",

--- a/Sources/Publisher+Async.swift
+++ b/Sources/Publisher+Async.swift
@@ -7,6 +7,7 @@
 import Combine
 
 @available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(macOS, deprecated: 12.0, message: "AsyncCompatibilityKit is only useful when targeting macOS versions earlier than 12")
 public extension Publisher {
     /// Convert this publisher into an `AsyncThrowingStream` that
     /// can be iterated over asynchronously using `for try await`.
@@ -38,6 +39,7 @@ public extension Publisher {
 }
 
 @available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(macOS, deprecated: 12.0, message: "AsyncCompatibilityKit is only useful when targeting macOS versions earlier than 12")
 public extension Publisher where Failure == Never {
     /// Convert this publisher into an `AsyncStream` that can
     /// be iterated over asynchronously using `for await`. The

--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 @available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(macOS, deprecated: 12.0, message: "AsyncCompatibilityKit is only useful when targeting macOS versions earlier than 12")
 public extension URLSession {
     /// Start a data task with a URL using async/await.
     /// - parameter url: The URL to send a request to.

--- a/Sources/View+Async.swift
+++ b/Sources/View+Async.swift
@@ -7,6 +7,7 @@
 import SwiftUI
 
 @available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(macOS, deprecated: 12.0, message: "AsyncCompatibilityKit is only useful when targeting macOS versions earlier than 12")
 public extension View {
     /// Attach an async task to this view, which will be performed
     /// when the view first appears, and cancelled if the view

--- a/Tests/ViewTests.swift
+++ b/Tests/ViewTests.swift
@@ -102,8 +102,14 @@ final class ViewTests: XCTestCase {
 
 private extension ViewTests {
     func showView<T: View>(_ view: T) {
+        #if os(iOS)
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIHostingController(rootView: view)
         window.makeKeyAndVisible()
+        #else
+        let window = NSWindow()
+        window.contentViewController = NSHostingController(rootView: view)
+        window.makeKeyAndOrderFront(nil)
+        #endif
     }
 }


### PR DESCRIPTION
Thank you for this! I used this in a multiplatform test project. I needed to change a few things for macOS support.

- Change package platforms to support Catalina and above
- Add macOS availability annotation with deprecation for Monterey
- Adjust showView helper for running tests on macOS

I also noticed that some of the tests are flaky with Xcode 13.2 on 11.6.2. It can be reproduced easily with the repeated tests feature in Xcode.

Example:

```swift
let subject = PassthroughSubject<Int, Never>()

let valueTask = Task<[Int], Never> {
  var values = [Int]()

  for await value in subject.values {
    values.append(value)
  }

  return values
}

Task {
  subject.send(1)
  subject.send(2)
  subject.send(3)
  subject.send(completion: .finished)
}

let values = await valueTask.value
XCTAssertEqual(values, [1, 2, 3])
```

Mac (11.6.2) as test platform:
```
Test Suite 'AsyncCompatibilityKitTests.xctest' failed at 2021-12-22 15:37:33.281.
	 Executed 100 tests, with 20 failures (0 unexpected) in 5.906 (6.114) seconds
```

It seems that the Task that sends the values and the finish event to the subject might run before the valueTask and then only the completion is received resulting in an empty array. Adding a short Task.sleep before sending the values fixes this as a workaround. I'm still learning how the new swift concurrency works. But I'm not sure about any guarantees for the order of execution of the two Task { } blocks here. The PassthroughSubject will drop values, if there's no subscriber yet.

Testing repeatedly on iOS simulators with iOS 13.7 or 14.5 also fails. 