### PR TITLE
Add "support" for iOS < 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 
 let package = Package(
     name: "AsyncCompatibilityKit",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v9)],
     products: [
         .library(
             name: "AsyncCompatibilityKit",

--- a/Sources/Publisher+Async.swift
+++ b/Sources/Publisher+Async.swift
@@ -6,7 +6,7 @@
 
 import Combine
 
-@available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(iOS, introduced: 13.0, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
 public extension Publisher {
     /// Convert this publisher into an `AsyncThrowingStream` that
     /// can be iterated over asynchronously using `for try await`.
@@ -37,7 +37,7 @@ public extension Publisher {
     }
 }
 
-@available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(iOS, introduced: 13.0, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
 public extension Publisher where Failure == Never {
     /// Convert this publisher into an `AsyncStream` that can
     /// be iterated over asynchronously using `for await`. The

--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-@available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(iOS, introduced: 13.0, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
 public extension URLSession {
     /// Start a data task with a URL using async/await.
     /// - parameter url: The URL to send a request to.

--- a/Sources/View+Async.swift
+++ b/Sources/View+Async.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-@available(iOS, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
+@available(iOS, introduced: 13.0, deprecated: 15.0, message: "AsyncCompatibilityKit is only useful when targeting iOS versions earlier than 15")
 public extension View {
     /// Attach an async task to this view, which will be performed
     /// when the view first appears, and cancelled if the view
@@ -25,6 +25,7 @@ public extension View {
     }
 }
 
+@available(iOS 13.0, *)
 private struct TaskModifier: ViewModifier {
     var priority: TaskPriority
     var action: () async -> Void

--- a/Tests/PublisherTests.swift
+++ b/Tests/PublisherTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import Combine
 import AsyncCompatibilityKit
 
+@available(iOS 13.0, *)
 final class PublisherTests: XCTestCase {
     func testValuesFromNonThrowingPublisher() async {
         let subject = PassthroughSubject<Int, Never>()

--- a/Tests/URLSessionTests.swift
+++ b/Tests/URLSessionTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import AsyncCompatibilityKit
 
+@available(iOS 13.0, *)
 final class URLSessionTests: XCTestCase {
     private let session = URLSession.shared
     private let fileContents = "Hello, world!"
@@ -81,6 +82,7 @@ final class URLSessionTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 private extension URLSessionTests {
     func verifyThatError(_ error: Error, containsURL url: URL) {
         // We don't want to make too many assumptions about the

--- a/Tests/ViewTests.swift
+++ b/Tests/ViewTests.swift
@@ -9,6 +9,7 @@ import Combine
 import SwiftUI
 import AsyncCompatibilityKit
 
+@available(iOS 13.0, *)
 final class ViewTests: XCTestCase {
     private var cancellables: Set<AnyCancellable>!
 
@@ -100,6 +101,7 @@ final class ViewTests: XCTestCase {
     }
 }
 
+@available(iOS 13.0, *)
 private extension ViewTests {
     func showView<T: View>(_ view: T) {
         let window = UIWindow(frame: UIScreen.main.bounds)


### PR DESCRIPTION
I'm trying to use this in a package that needs to be compatible with iOS 12, but simply integrating `AsyncCompatibilityKit` results in an error:

<img width="398" alt="Screenshot 2021-12-24 at 07 22 06" src="https://user-images.githubusercontent.com/16212751/147325101-763fb770-a73e-4a48-899a-1210ec24c889.png">

The fix:
Add `introduced: 13.0` to the `@available` statements: This way, consumers can import the package on iOS <13 (where it does nothing).