### PR TITLE
Download

### DIFF
--- a/Sources/URLSession+Async.swift
+++ b/Sources/URLSession+Async.swift
@@ -45,6 +45,50 @@ public extension URLSession {
     }
 }
 
+extension URLSession {
+    @available(iOS, deprecated: 15, message: "Use `download(from:delegate:)` instead")
+    func download(from url: URL) async throws -> (URL, URLResponse) {
+        try await download(with: URLRequest(url: url))
+    }
+
+    @available(iOS, deprecated: 15, message: "Use `download(for:delegate:)` instead")
+    func download(with request: URLRequest) async throws -> (URL, URLResponse) {
+        let sessionTask = URLSessionTaskActor()
+
+        return try await withTaskCancellationHandler {
+            Task { await sessionTask.cancel() }
+        } operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    await sessionTask.start(downloadTask(with: request) { location, response, error in
+                        guard let location = location, let response = response else {
+                            continuation.resume(throwing: error ?? URLError(.badServerResponse))
+                            return
+                        }
+
+                        // since continuation can happen later, let's figure out where to store it ...
+
+                        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                            .appendingPathComponent(UUID().uuidString)
+                            .appendingPathExtension(request.url!.pathExtension)
+
+                        // ... and move it to there
+
+                        do {
+                            try FileManager.default.moveItem(at: location, to: tempURL)
+                        } catch {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+
+                        continuation.resume(returning: (tempURL, response))
+                    })
+                }
+            }
+        }
+    }
+}
+
 private actor URLSessionTaskActor {
     weak var task: URLSessionTask?
 


### PR DESCRIPTION
Add download tasks

* Note, though, that unlike the data task, I made the method name distinct (using `with` rather than `for`/`from`).
* Should the data task also use unique names rather than counterfeiting the iOS 15 method names?
* This uses the `actor` pattern referenced in my other pull request.
* If you approve of this pull request, I'm happy to do an upload task rendition, too.
