### PR TITLE
Support immediate data task cancellation

### DIFF
--- a/Tests/URLSessionTests.swift
+++ b/Tests/URLSessionTests.swift
@@ -65,6 +65,21 @@ final class URLSessionTests: XCTestCase {
         }
     }
 
+    func testCancellingTaskCancelsDataTaskBeforeResuming() async throws {
+        let task = Task { try await session.data(from: fileURL) }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected error to be thrown")
+        } catch let error as URLError {
+            verifyThatError(error, containsURL: fileURL)
+            XCTAssertEqual(error.code, .cancelled)
+        } catch {
+            XCTFail("Invalid error thrown: \(error)")
+        }
+    }
+
     func testCancellingParentTaskCancelsDataTask() async throws {
         let task = Task { try await session.data(from: fileURL) }
         Task { task.cancel() }


### PR DESCRIPTION
While testing my unit tests (which were working fine on iOS 15) with the back ported version of `URLSession.data(for:)` from `AsyncCompatibilityKit` the cancelation test stopped working even though the package implements task cancellation.

So I was analyzing the issue and found, that task cancellations immediately following the task creation were not considered because the `URLSessionDataTask` was not yet created, therefore the `dataTask` was `nil`.

So I've implemented a `shouldCancel` flag which is set by the `onCancel` handler and considered before resuming the task.

I hope this is also useful to other library users.